### PR TITLE
fix: replace emit with push

### DIFF
--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ module.exports = function gulpSvelte(...args) {
 				cssFile.contents = Buffer.from(result.css.code);
 				vinylSourcemapsApply(cssFile.contents, result.css.map);
 
-				this.emit('data', cssFile);
+				this.push(cssFile);
 			}
 
 			if (file.path) {


### PR DESCRIPTION
For some reason, using `emit('data', cssFile)` results in the gulp task never finishing **if you have a large number of files** with Svelte components and each one having some CSS. Replacing it with `push` fixes the problem, while still keeping the functionality same.

Check the zip file with the code which reproduces the bug: [test.zip](https://github.com/shinnn/gulp-svelte/files/2217427/test.zip)